### PR TITLE
[#672](https://github.com/clojerl/clojerl/issues/672) Create asdf installer for Clojerl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # Clojerl asdf plugin
+
+[Clojerl](https://github.com/clojerl/clojerl) plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
+
+## Install
+
+> *Clojerl requires Erlang to be installed. You can use the [asdf-erlang](https://github.com/asdf-vm/asdf-erlang) plugin to install Erlang versions.*
+
+```
+asdf plugin-add clojerl https://github.com/clojerl/asdf-clojerl.git
+```
+
+## Use
+
+Check [asdf](https://github.com/asdf-vm/asdf) readme for instructions on how to install & manage versions of LFE.
+
+
+Derived from [asdf-lfe](https://github.com/asdf-community/asdf-lfe) and [asdf-elixir](https://github.com/asdf-vm/asdf-elixir)

--- a/bin/download
+++ b/bin/download
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -Eiuo pipefail
+
+printf "Downloading clojerl %s\n" "${ASDF_INSTALL_VERSION}"
+
+# This is needed because asdf prompts for permission to remove read-only git packfiles
+trap 'rm -rf "${ASDF_DOWNLOAD_PATH}/.git"' EXIT
+git clone --depth 1 --branch "$ASDF_INSTALL_VERSION" "https://github.com/clojerl/clojerl" "$ASDF_DOWNLOAD_PATH"
+

--- a/bin/install
+++ b/bin/install
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -Eiuo pipefail
+
+printf "Installing clojerl %s\n" "$ASDF_INSTALL_VERSION"
+
+if [[ "$ASDF_DOWNLOAD_PATH" == "" ]] ; then
+    tmpdir="$(mktemp -d -t 'asdf_XXXXXXXXXX')"
+    export ASDF_DOWNLOAD_PATH="$tmpdir"
+    trap 'rm -rf "$ASDF_DOWNLOAD_PATH"' EXIT
+    "$(dirname "$0")/download"
+fi
+
+cp -R "${ASDF_DOWNLOAD_PATH}/." "$ASDF_INSTALL_PATH"
+
+# Build from source in a subshell because we don't want to disturb current working dir
+# Reference: https://github.com/asdf-vm/asdf-elixir/blob/master/bin/install#L64
+(
+  cd "$ASDF_INSTALL_PATH" || exit;
+  make
+)
+
+if [ $? -ne 0 ]; then
+  echo "Build failed, cleaning..."
+  rm -rf "$ASDF_INSTALL_PATH"
+  exit 1
+fi

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+releases_path=https://api.github.com/repos/clojerl/clojerl/tags
+cmd="curl -sL"
+if [ -n "$OAUTH_TOKEN" ]; then
+  cmd="$cmd -H 'Authorization: token $OAUTH_TOKEN'"
+fi
+cmd="$cmd $releases_path"
+
+sort_cmd='sort'
+if sort --help | grep -q -- '-V'; then
+  sort_cmd='sort -V'
+fi
+
+# Fetch all tag names, and get only second column. Then remove all unnecesary characters.
+versions=$(eval "$cmd" | \
+  tee | \
+  grep -oE "name\": \".{1,15}\"," | \
+  sed 's/name\": \"//;s/\",//' | \
+  "$sort_cmd" | \
+  tr '\n' ' ')
+
+echo "$versions"


### PR DESCRIPTION
Clojerl is a really interesting project that brings Clojure, this amazing programming language to the awesome BEAM platform. But as all BEAM languages, Clojerl deserves its own asdf installer, so here it is.

During the development of this plugin, I cannot install previous versions of Clojerl only the master build successfully.

I executed this steps:

```
git clone --depth 1 --branch 0.7.0 https://github.com/clojerl/clojerl
cd clojerl
make
```

I got this output:

```
===> Fetching rebar3_clojerl v0.8.3
===> Version cached at /Users/marcio.faria/.cache/rebar3/hex/hexpm/packages/rebar3_clojerl-0.8.3.tar is up to date, reusing it
===> Analyzing applications...
===> Compiling rebar3_clojerl
===> Failed creating providers. Run with DEBUG=1 for stacktrace or consult rebar3.crashdump.
make: *** [compile] Error 1
```

By the way, this plugin seems to works as expected.